### PR TITLE
update to some country names

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -77,7 +77,7 @@
     },
     {
         "value": "BQ",
-        "label": "Bonaire, Saint Eustatius and Saba "
+        "label": "Bonaire, Sint Eustatius and Saba"
     },
     {
         "value": "BR",
@@ -649,7 +649,7 @@
     },
     {
         "value": "CV",
-        "label": "Cape Verde"
+        "label": "Cabo Verde"
     },
     {
         "value": "CU",
@@ -657,7 +657,7 @@
     },
     {
         "value": "SZ",
-        "label": "Swaziland"
+        "label": "Eswatini"
     },
     {
         "value": "SY",


### PR DESCRIPTION
Some internationally accepted/ used country names are not being used in Travel Advisory rss feed, so I found the differences and applied them into our country names in order to have same names as travel advisory rss feed.